### PR TITLE
Some fixes

### DIFF
--- a/Sources/Discourse/Command.swift
+++ b/Sources/Discourse/Command.swift
@@ -33,7 +33,7 @@ public extension Command {
     func populateArguments(from passedArguments: [String]) throws {
         var argumentPairs: [String: String] = [:]
         stride(from: 0, to: passedArguments.count - 1, by: 2).forEach {
-            argumentPairs[passedArguments[$0]] = passedArguments[$0 + 1].escapedCommandLineString
+            argumentPairs[passedArguments[$0].escapedCommandLineString] = passedArguments[$0 + 1].escapedCommandLineString
         }
 
         try arguments.forEach { commandArg in

--- a/Sources/Discourse/CommandHandler.swift
+++ b/Sources/Discourse/CommandHandler.swift
@@ -35,7 +35,7 @@ public class CommandHandler {
 
     public func run() throws {
         var standardOutput: TextOutputStream = StandardOutput()
-        try run(verb: CommandLine.verb, arguments: CommandLine.arguments, outputStream: &standardOutput)
+        try run(verb: CommandLine.verb, arguments: CommandLine.commandArguments, outputStream: &standardOutput)
     }
 
     /// Attempts to run a registered command for the specified `verb` and `arguments`.

--- a/Sources/Discourse/CommandHandler.swift
+++ b/Sources/Discourse/CommandHandler.swift
@@ -40,7 +40,7 @@ public class CommandHandler {
 
     /// Attempts to run a registered command for the specified `verb` and `arguments`.
     public func run(verb: String?, arguments: [String]?, outputStream: inout TextOutputStream) throws {
-        guard let arguments = arguments?.dropFirst(),
+        guard let arguments = arguments?,
             let command = commands.first(where: { $0.verb == verb }) else {
             throw HandlerError.unknownCommand(verb, usage())
         }

--- a/Sources/Discourse/CommandHandler.swift
+++ b/Sources/Discourse/CommandHandler.swift
@@ -40,7 +40,7 @@ public class CommandHandler {
 
     /// Attempts to run a registered command for the specified `verb` and `arguments`.
     public func run(verb: String?, arguments: [String]?, outputStream: inout TextOutputStream) throws {
-        guard let arguments = arguments?,
+        guard let arguments = arguments,
             let command = commands.first(where: { $0.verb == verb }) else {
             throw HandlerError.unknownCommand(verb, usage())
         }

--- a/Sources/Discourse/CommandLine+Extensions.swift
+++ b/Sources/Discourse/CommandLine+Extensions.swift
@@ -21,6 +21,6 @@ extension CommandLine {
     }
 
     static var commandArguments: [String] {
-        return Array(usableArguments[1...])
+        return Array(usableArguments.dropFirst())
     }
 }

--- a/Sources/Discourse/CommandLine+Extensions.swift
+++ b/Sources/Discourse/CommandLine+Extensions.swift
@@ -11,12 +11,16 @@ extension CommandLine {
     private static var allArguments: ArraySlice<String> {
         return arguments[CommandLine.arguments.indices]
     }
+    
+    private static var usableArguments: ArraySlice<String> {
+        return allArguments.dropFirst()
+    }
 
     static var verb: String? {
-        return allArguments.dropFirst().first
+        return usableArguments.first
     }
 
     static var commandArguments: [String] {
-        return Array(allArguments[1...])
+        return Array(usableArguments[1...])
     }
 }


### PR DESCRIPTION
Improves parsing of command line arguments by stripping the verb earlier and then escaping the argument name properly